### PR TITLE
Add support for iCalendar export (iOS and Mac)

### DIFF
--- a/_data/programme/update_programme.py
+++ b/_data/programme/update_programme.py
@@ -30,7 +30,7 @@ def download_file(file_id):
     done = False
     while done is False:
         status, done = downloader.next_chunk()
-    return io.BytesIO(fh.getvalue()) 
+    return io.BytesIO(fh.getvalue())
 
 
 speakers_csv = csv.reader(
@@ -136,12 +136,16 @@ for speaker_slug in sorted(speakers.keys()):
 yaml.dump(sessions, open('sessions.yml', 'wt'))
 
 # For each session, make sure there is a corresponding .html page in sessions/
-front_matter = """---
+front_matter_html = """---
 layout: session
 slug: {slug}
 title: "{title} // The World Transformed"
 image: "sessions/{image}.jpg"
 description: "A session at {time} on {day} in {venue}{room}{details}"
+---"""
+front_matter_ics = """---
+layout: icalendar
+slug: {slug}
 ---"""
 for slug, session in sessions.iteritems():
     # If there's an organiser, mention that
@@ -150,10 +154,10 @@ for slug, session in sessions.iteritems():
     else:
         details = ''
 
-    filename = '../../sessions/%s.html' % slug
-    file = open(filename, 'wt')
+    filename_html = '../../sessions/%s.html' % slug
+    file = open(filename_html, 'wt')
     file.write(
-        front_matter.format(
+        front_matter_html.format(
             slug=slug,
             title=session['title'].replace('"', '\\"'),
             image=session['image'],
@@ -163,6 +167,13 @@ for slug, session in sessions.iteritems():
             room=' ' + session['room'] if session['room'] else '',
             details=details
         )
+    )
+    file.close()
+
+    filename_ics = '../../sessions/%s.ics' % slug
+    file = open(filename_ics, 'wt')
+    file.write(
+        front_matter_ics.format(slug=slug)
     )
     file.close()
 

--- a/_includes/speakers.html
+++ b/_includes/speakers.html
@@ -1,1 +1,1 @@
-{% assign slugs=include.speakers|split:" " %}{% for slug in slugs %}{% assign speaker = site.data.programme.speakers[slug] %}{{ speaker.name }}{% unless forloop.last %}, {% endunless %}{% endfor %}
+{%- assign slugs=include.speakers|split:" " -%}{%- for slug in slugs -%}{%- assign speaker = site.data.programme.speakers[slug] -%}{{ speaker.name }}{%- unless forloop.last -%}, {%- endunless -%}{%- endfor -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,5 +49,11 @@
     <script src="/semantic/dist/semantic.min.js"></script>
     <script src="/js/jquery.scrollie.min.js"></script>
     <script src="/js/scripts.js?1"></script>
+    <script>
+      $('.modal-open').click(function(e) {
+        e.preventDefault();
+        $('.ui.modal').modal('show');
+      });
+    </script>
 </body>
 </html>

--- a/_layouts/icalendar.ics
+++ b/_layouts/icalendar.ics
@@ -1,0 +1,17 @@
+---
+layout: none
+---
+{%- assign session = site.data.programme.sessions[page.slug] -%}
+{%- capture speakers -%}{%- include speakers.html speakers=session.speakers -%}{%- endcapture -%}
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:{{ page.slug }}@theworldtransformed.org
+DTSTAMP;TZID=Europe/London:{{ session.start_timestamp }}
+DTSTART;TZID=Europe/London:{{ session.start_timestamp }}
+DTEND;TZID=Europe/London:{{ session.end_timestamp }}
+SUMMARY:{{ session.title }}
+DESCRIPTION:{% unless session.organiser == '' %}Organised by {{ session.organiser }}. {% endunless %}{% unless speakers == '' %}Featuring {{ speakers | strip_newlines }}. {% endunless %}Details on The World Transformed website at {{ site.url }}/sessions/{{ page.slug }}.html
+LOCATION:{{ session.venue }} {{ session.room }}
+END:VEVENT
+END:VCALENDAR

--- a/_layouts/session.html
+++ b/_layouts/session.html
@@ -40,17 +40,10 @@ layout: default
                 <div class="three wide column">
                     {% capture speakers %}{% include speakers.html speakers=session.speakers %}
 {% endcapture %}
-                    <a class="ui icon blue button"
-                       href="http://www.google.com/calendar/render?action=TEMPLATE&text={{ session.title|url_encode }}&dates={{ session.start_timestamp }}/{{ session.end_timestamp }}&details={% unless session.organiser == '' %}Organised+by+{{ session.organiser|url_encode }}.+{% endunless %}{% unless session.speakers == '' %}Featuring {{ speakers|url_encode }}{% endunless %}Details+on+The+World+Transformed+website+at+{{ site.url }}{{ page.url }}&location={{ session.venue|url_encode }}+{{ session.room|url_encode }}&sf=true&output=xml"
-                       target="_blank" rel="nofollow">
+                    <a class="ui icon blue button modal-open"
+                       href="http://www.google.com/calendar/render?action=TEMPLATE&text={{ session.title|url_encode }}&dates={{ session.start_timestamp }}/{{ session.end_timestamp }}&details={% unless session.organiser == '' %}Organised+by+{{ session.organiser|url_encode }}.+{% endunless %}{% unless session.speakers == '' %}Featuring {{ speakers|url_encode }}{% endunless %}Details+on+The+World+Transformed+website+at+{{ site.url }}{{ page.url }}&location={{ session.venue|url_encode }}+{{ session.room|url_encode }}&sf=true&output=xml">
                        <i class="calendar alternate icon"></i>
-                       Add to Google calendar
-                    </a>
-                    <a class="ui icon blue button"
-                       href="/sessions/{{ page.slug }}.ics"
-                       target="_blank" rel="nofollow">
-                       <i class="calendar alternate icon"></i>
-                       Add to Apple calendar
+                       Add to calendar
                     </a>
                 </div>
             </div>
@@ -114,4 +107,24 @@ layout: default
             {% endif %}
         </div>
     </div>
+</div>
+<div class="ui modal tiny">
+  <div class="content">
+    <div class="ui list">
+      <div class="item">
+        <a href="http://www.google.com/calendar/render?action=TEMPLATE&text={{ session.title|url_encode }}&dates={{ session.start_timestamp }}/{{ session.end_timestamp }}&details={% unless session.organiser == '' %}Organised+by+{{ session.organiser|url_encode }}.+{% endunless %}{% unless session.speakers == '' %}Featuring {{ speakers|url_encode }}{% endunless %}Details+on+The+World+Transformed+website+at+{{ site.url }}{{ page.url }}&location={{ session.venue|url_encode }}+{{ session.room|url_encode }}&sf=true&output=xml"
+           target="_blank" rel="nofollow">
+          <i class="google alternate icon"></i>
+          Add to Google calendar
+        </a>
+      </div>
+      <div class="item">
+        <a href="/sessions/{{ page.slug }}.ics"
+           target="_blank" rel="nofollow">
+          <i class="apple alternate icon"></i>
+          Add to Apple calendar
+        </a>
+      </div>
+    </div>
+  </div>
 </div>

--- a/_layouts/session.html
+++ b/_layouts/session.html
@@ -46,6 +46,12 @@ layout: default
                        <i class="calendar alternate icon"></i>
                        Add to Google calendar
                     </a>
+                    <a class="ui icon blue button"
+                       href="/sessions/{{ page.slug }}.ics"
+                       target="_blank" rel="nofollow">
+                       <i class="calendar alternate icon"></i>
+                       Add to Apple calendar
+                    </a>
                 </div>
             </div>
             <br />

--- a/sessions/4-day-week.ics
+++ b/sessions/4-day-week.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: 4-day-week
+---

--- a/sessions/M.APP-and-beyond.ics
+++ b/sessions/M.APP-and-beyond.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: M.APP-and-beyond
+---

--- a/sessions/a-global-nhs.ics
+++ b/sessions/a-global-nhs.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: a-global-nhs
+---

--- a/sessions/a-movement-in-government.ics
+++ b/sessions/a-movement-in-government.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: a-movement-in-government
+---

--- a/sessions/a-movement-led-media.ics
+++ b/sessions/a-movement-led-media.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: a-movement-led-media
+---

--- a/sessions/a-new-economic-consensus.ics
+++ b/sessions/a-new-economic-consensus.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: a-new-economic-consensus
+---

--- a/sessions/a-new-populism.ics
+++ b/sessions/a-new-populism.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: a-new-populism
+---

--- a/sessions/a-party-for-the-21st-century.ics
+++ b/sessions/a-party-for-the-21st-century.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: a-party-for-the-21st-century
+---

--- a/sessions/a-plan-for-the-new-economy.ics
+++ b/sessions/a-plan-for-the-new-economy.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: a-plan-for-the-new-economy
+---

--- a/sessions/a-radical-alliance-for-europe.ics
+++ b/sessions/a-radical-alliance-for-europe.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: a-radical-alliance-for-europe
+---

--- a/sessions/a-socialist-story-of-modern-britain.ics
+++ b/sessions/a-socialist-story-of-modern-britain.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: a-socialist-story-of-modern-britain
+---

--- a/sessions/a-very-british-coup.ics
+++ b/sessions/a-very-british-coup.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: a-very-british-coup
+---

--- a/sessions/a-working-class-party.ics
+++ b/sessions/a-working-class-party.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: a-working-class-party
+---

--- a/sessions/a-world-without-prisons.ics
+++ b/sessions/a-world-without-prisons.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: a-world-without-prisons
+---

--- a/sessions/acid-corbynism.ics
+++ b/sessions/acid-corbynism.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: acid-corbynism
+---

--- a/sessions/alborada-latin-america.ics
+++ b/sessions/alborada-latin-america.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: alborada-latin-america
+---

--- a/sessions/an-evening-of-internationalism.ics
+++ b/sessions/an-evening-of-internationalism.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: an-evening-of-internationalism
+---

--- a/sessions/an-intersection-of-class-and-gender.ics
+++ b/sessions/an-intersection-of-class-and-gender.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: an-intersection-of-class-and-gender
+---

--- a/sessions/apps-for-the-many.ics
+++ b/sessions/apps-for-the-many.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: apps-for-the-many
+---

--- a/sessions/artists-4-corbyn.ics
+++ b/sessions/artists-4-corbyn.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: artists-4-corbyn
+---

--- a/sessions/beating-the-bosses.ics
+++ b/sessions/beating-the-bosses.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: beating-the-bosses
+---

--- a/sessions/beyond-cultural-precarity.ics
+++ b/sessions/beyond-cultural-precarity.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: beyond-cultural-precarity
+---

--- a/sessions/big-organising.ics
+++ b/sessions/big-organising.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: big-organising
+---

--- a/sessions/black-flowers.ics
+++ b/sessions/black-flowers.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: black-flowers
+---

--- a/sessions/black-women-transforming-politics.ics
+++ b/sessions/black-women-transforming-politics.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: black-women-transforming-politics
+---

--- a/sessions/brazilian-films.ics
+++ b/sessions/brazilian-films.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: brazilian-films
+---

--- a/sessions/bringing-twt-to-your-community.ics
+++ b/sessions/bringing-twt-to-your-community.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: bringing-twt-to-your-community
+---

--- a/sessions/britains-new-far-right.ics
+++ b/sessions/britains-new-far-right.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: britains-new-far-right
+---

--- a/sessions/building-community-wealth.ics
+++ b/sessions/building-community-wealth.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: building-community-wealth
+---

--- a/sessions/building-local-campaigns-that-win.ics
+++ b/sessions/building-local-campaigns-that-win.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: building-local-campaigns-that-win
+---

--- a/sessions/calais-jungle.ics
+++ b/sessions/calais-jungle.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: calais-jungle
+---

--- a/sessions/campaign-building.ics
+++ b/sessions/campaign-building.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: campaign-building
+---

--- a/sessions/can't-start-a-fire-without-a-flame.ics
+++ b/sessions/can't-start-a-fire-without-a-flame.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: can't-start-a-fire-without-a-flame
+---

--- a/sessions/cities-in-common.ics
+++ b/sessions/cities-in-common.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: cities-in-common
+---

--- a/sessions/class-justice.ics
+++ b/sessions/class-justice.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: class-justice
+---

--- a/sessions/clement-atlee-play.ics
+++ b/sessions/clement-atlee-play.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: clement-atlee-play
+---

--- a/sessions/closing-party.ics
+++ b/sessions/closing-party.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: closing-party
+---

--- a/sessions/codespace-monday.ics
+++ b/sessions/codespace-monday.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: codespace-monday
+---

--- a/sessions/codespace-sunday.ics
+++ b/sessions/codespace-sunday.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: codespace-sunday
+---

--- a/sessions/codespace-tuesday.ics
+++ b/sessions/codespace-tuesday.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: codespace-tuesday
+---

--- a/sessions/colombia-the-human-rights-crisis.ics
+++ b/sessions/colombia-the-human-rights-crisis.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: colombia-the-human-rights-crisis
+---

--- a/sessions/communities-against-climate-change.ics
+++ b/sessions/communities-against-climate-change.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: communities-against-climate-change
+---

--- a/sessions/conversation-with-jean-luc-melenchon.ics
+++ b/sessions/conversation-with-jean-luc-melenchon.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: conversation-with-jean-luc-melenchon
+---

--- a/sessions/cracked-play.ics
+++ b/sessions/cracked-play.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: cracked-play
+---

--- a/sessions/creative-campaigning.ics
+++ b/sessions/creative-campaigning.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: creative-campaigning
+---

--- a/sessions/creative-class.ics
+++ b/sessions/creative-class.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: creative-class
+---

--- a/sessions/cybernetic-socialism.ics
+++ b/sessions/cybernetic-socialism.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: cybernetic-socialism
+---

--- a/sessions/debunking-the-myths.ics
+++ b/sessions/debunking-the-myths.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: debunking-the-myths
+---

--- a/sessions/decolonisation.ics
+++ b/sessions/decolonisation.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: decolonisation
+---

--- a/sessions/decolonising-foreign-policy.ics
+++ b/sessions/decolonising-foreign-policy.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: decolonising-foreign-policy
+---

--- a/sessions/decolonising-yoga.ics
+++ b/sessions/decolonising-yoga.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: decolonising-yoga
+---

--- a/sessions/deconstructing-neoliberalism-monday.ics
+++ b/sessions/deconstructing-neoliberalism-monday.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: deconstructing-neoliberalism-monday
+---

--- a/sessions/deconstructing-neoliberalism-sunday.ics
+++ b/sessions/deconstructing-neoliberalism-sunday.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: deconstructing-neoliberalism-sunday
+---

--- a/sessions/deconstructing-neoliberalism-tuesday.ics
+++ b/sessions/deconstructing-neoliberalism-tuesday.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: deconstructing-neoliberalism-tuesday
+---

--- a/sessions/developing-labours-nes.ics
+++ b/sessions/developing-labours-nes.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: developing-labours-nes
+---

--- a/sessions/developing-movement-leaders.ics
+++ b/sessions/developing-movement-leaders.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: developing-movement-leaders
+---

--- a/sessions/digital-economy-101.ics
+++ b/sessions/digital-economy-101.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: digital-economy-101
+---

--- a/sessions/disrupting-the-status-quo.ics
+++ b/sessions/disrupting-the-status-quo.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: disrupting-the-status-quo
+---

--- a/sessions/eco-corbynism-mon.ics
+++ b/sessions/eco-corbynism-mon.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: eco-corbynism-mon
+---

--- a/sessions/eco-corbynism-monday.ics
+++ b/sessions/eco-corbynism-monday.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: eco-corbynism-monday
+---

--- a/sessions/eco-corbynism-reading-group.ics
+++ b/sessions/eco-corbynism-reading-group.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: eco-corbynism-reading-group
+---

--- a/sessions/eco-corbynism-sun.ics
+++ b/sessions/eco-corbynism-sun.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: eco-corbynism-sun
+---

--- a/sessions/eco-corbynism-sunday.ics
+++ b/sessions/eco-corbynism-sunday.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: eco-corbynism-sunday
+---

--- a/sessions/eco-corbynism-tuesday.ics
+++ b/sessions/eco-corbynism-tuesday.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: eco-corbynism-tuesday
+---

--- a/sessions/ed-miliband-quiz.ics
+++ b/sessions/ed-miliband-quiz.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: ed-miliband-quiz
+---

--- a/sessions/education-in-the-labour-party.ics
+++ b/sessions/education-in-the-labour-party.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: education-in-the-labour-party
+---

--- a/sessions/end-to-sex-work-criminalisation.ics
+++ b/sessions/end-to-sex-work-criminalisation.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: end-to-sex-work-criminalisation
+---

--- a/sessions/ending-the-drug-war.ics
+++ b/sessions/ending-the-drug-war.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: ending-the-drug-war
+---

--- a/sessions/feeling-the-bern.ics
+++ b/sessions/feeling-the-bern.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: feeling-the-bern
+---

--- a/sessions/feminism-for-the-many.ics
+++ b/sessions/feminism-for-the-many.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: feminism-for-the-many
+---

--- a/sessions/fighting-back-against-the-tech-giants.ics
+++ b/sessions/fighting-back-against-the-tech-giants.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: fighting-back-against-the-tech-giants
+---

--- a/sessions/fighting-disabled-exclusion.ics
+++ b/sessions/fighting-disabled-exclusion.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: fighting-disabled-exclusion
+---

--- a/sessions/fighting-for-trans-liberation.ics
+++ b/sessions/fighting-for-trans-liberation.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: fighting-for-trans-liberation
+---

--- a/sessions/film-nae-pasaran.ics
+++ b/sessions/film-nae-pasaran.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: film-nae-pasaran
+---

--- a/sessions/folding-our-futures.ics
+++ b/sessions/folding-our-futures.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: folding-our-futures
+---

--- a/sessions/future-of-trade-unions.ics
+++ b/sessions/future-of-trade-unions.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: future-of-trade-unions
+---

--- a/sessions/future-visions.ics
+++ b/sessions/future-visions.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: future-visions
+---

--- a/sessions/generation-solidarity.ics
+++ b/sessions/generation-solidarity.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: generation-solidarity
+---

--- a/sessions/getting-your-local-groups-working.ics
+++ b/sessions/getting-your-local-groups-working.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: getting-your-local-groups-working
+---

--- a/sessions/global-finance-101.ics
+++ b/sessions/global-finance-101.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: global-finance-101
+---

--- a/sessions/good-and-bad-government.ics
+++ b/sessions/good-and-bad-government.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: good-and-bad-government
+---

--- a/sessions/group-dynamics-and-movement-building.ics
+++ b/sessions/group-dynamics-and-movement-building.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: group-dynamics-and-movement-building
+---

--- a/sessions/history-lessons.ics
+++ b/sessions/history-lessons.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: history-lessons
+---

--- a/sessions/housing-for-all.ics
+++ b/sessions/housing-for-all.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: housing-for-all
+---

--- a/sessions/how-to-win-big.ics
+++ b/sessions/how-to-win-big.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: how-to-win-big
+---

--- a/sessions/in-and-against-the-state.ics
+++ b/sessions/in-and-against-the-state.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: in-and-against-the-state
+---

--- a/sessions/internationalist-labour-party.ics
+++ b/sessions/internationalist-labour-party.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: internationalist-labour-party
+---

--- a/sessions/intro-to-coding.ics
+++ b/sessions/intro-to-coding.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: intro-to-coding
+---

--- a/sessions/jobs-in-nuclear-weapons.ics
+++ b/sessions/jobs-in-nuclear-weapons.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: jobs-in-nuclear-weapons
+---

--- a/sessions/kids-write-plays-performance.ics
+++ b/sessions/kids-write-plays-performance.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: kids-write-plays-performance
+---

--- a/sessions/kids-write-plays.ics
+++ b/sessions/kids-write-plays.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: kids-write-plays
+---

--- a/sessions/king-a-film-record.ics
+++ b/sessions/king-a-film-record.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: king-a-film-record
+---

--- a/sessions/latin-america.ics
+++ b/sessions/latin-america.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: latin-america
+---

--- a/sessions/lessons-from-the-ucu-strike.ics
+++ b/sessions/lessons-from-the-ucu-strike.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: lessons-from-the-ucu-strike
+---

--- a/sessions/live-illustration-workshop.ics
+++ b/sessions/live-illustration-workshop.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: live-illustration-workshop
+---

--- a/sessions/liverpools-history-of-slavery.ics
+++ b/sessions/liverpools-history-of-slavery.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: liverpools-history-of-slavery
+---

--- a/sessions/living-the-climate-crisis.ics
+++ b/sessions/living-the-climate-crisis.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: living-the-climate-crisis
+---

--- a/sessions/long-live-southbank.ics
+++ b/sessions/long-live-southbank.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: long-live-southbank
+---

--- a/sessions/making-grassroots-media.ics
+++ b/sessions/making-grassroots-media.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: making-grassroots-media
+---

--- a/sessions/mapp-and-beyond.ics
+++ b/sessions/mapp-and-beyond.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: mapp-and-beyond
+---

--- a/sessions/martin-luther-king.ics
+++ b/sessions/martin-luther-king.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: martin-luther-king
+---

--- a/sessions/marx-at-200.ics
+++ b/sessions/marx-at-200.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: marx-at-200
+---

--- a/sessions/marxism-101.ics
+++ b/sessions/marxism-101.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: marxism-101
+---

--- a/sessions/mental-health-and-capitalism.ics
+++ b/sessions/mental-health-and-capitalism.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: mental-health-and-capitalism
+---

--- a/sessions/migrant-political-voices.ics
+++ b/sessions/migrant-political-voices.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: migrant-political-voices
+---

--- a/sessions/mind-the-gap.ics
+++ b/sessions/mind-the-gap.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: mind-the-gap
+---

--- a/sessions/more-earth.ics
+++ b/sessions/more-earth.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: more-earth
+---

--- a/sessions/movement-for-cultural-democracy.ics
+++ b/sessions/movement-for-cultural-democracy.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: movement-for-cultural-democracy
+---

--- a/sessions/music-in-the-movement.ics
+++ b/sessions/music-in-the-movement.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: music-in-the-movement
+---

--- a/sessions/nae-pasaran.ics
+++ b/sessions/nae-pasaran.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: nae-pasaran
+---

--- a/sessions/nature-of-the-beast.ics
+++ b/sessions/nature-of-the-beast.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: nature-of-the-beast
+---

--- a/sessions/no-pasaran.ics
+++ b/sessions/no-pasaran.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: no-pasaran
+---

--- a/sessions/occupy-fleet-street.ics
+++ b/sessions/occupy-fleet-street.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: occupy-fleet-street
+---

--- a/sessions/opening-party.ics
+++ b/sessions/opening-party.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: opening-party
+---

--- a/sessions/painting-the-towns-red.ics
+++ b/sessions/painting-the-towns-red.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: painting-the-towns-red
+---

--- a/sessions/parties-and-picket-lines.ics
+++ b/sessions/parties-and-picket-lines.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: parties-and-picket-lines
+---

--- a/sessions/poets-corner.ics
+++ b/sessions/poets-corner.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: poets-corner
+---

--- a/sessions/political-education-forum.ics
+++ b/sessions/political-education-forum.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: political-education-forum
+---

--- a/sessions/popular-education-forum.ics
+++ b/sessions/popular-education-forum.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: popular-education-forum
+---

--- a/sessions/post-brexit.ics
+++ b/sessions/post-brexit.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: post-brexit
+---

--- a/sessions/power-for-the-many.ics
+++ b/sessions/power-for-the-many.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: power-for-the-many
+---

--- a/sessions/power-mapping.ics
+++ b/sessions/power-mapping.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: power-mapping
+---

--- a/sessions/progressive-nationalism.ics
+++ b/sessions/progressive-nationalism.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: progressive-nationalism
+---

--- a/sessions/queer-liberation-and-assimilation.ics
+++ b/sessions/queer-liberation-and-assimilation.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: queer-liberation-and-assimilation
+---

--- a/sessions/question-time.ics
+++ b/sessions/question-time.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: question-time
+---

--- a/sessions/racisms-past-and-present.ics
+++ b/sessions/racisms-past-and-present.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: racisms-past-and-present
+---

--- a/sessions/radical-history-tour.ics
+++ b/sessions/radical-history-tour.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: radical-history-tour
+---

--- a/sessions/react-workshop.ics
+++ b/sessions/react-workshop.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: react-workshop
+---

--- a/sessions/reading-group-antisemitism-monday.ics
+++ b/sessions/reading-group-antisemitism-monday.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: reading-group-antisemitism-monday
+---

--- a/sessions/reading-group-antisemitism-sunday.ics
+++ b/sessions/reading-group-antisemitism-sunday.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: reading-group-antisemitism-sunday
+---

--- a/sessions/reading-group-antisemitism-tuesday.ics
+++ b/sessions/reading-group-antisemitism-tuesday.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: reading-group-antisemitism-tuesday
+---

--- a/sessions/red-white-blue-labour.ics
+++ b/sessions/red-white-blue-labour.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: red-white-blue-labour
+---

--- a/sessions/regenerating-regeneration.ics
+++ b/sessions/regenerating-regeneration.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: regenerating-regeneration
+---

--- a/sessions/relative-poverty.ics
+++ b/sessions/relative-poverty.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: relative-poverty
+---

--- a/sessions/rentquake.ics
+++ b/sessions/rentquake.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: rentquake
+---

--- a/sessions/representation-in-film.ics
+++ b/sessions/representation-in-film.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: representation-in-film
+---

--- a/sessions/runaway-finance.ics
+++ b/sessions/runaway-finance.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: runaway-finance
+---

--- a/sessions/sacrifice-zones.ics
+++ b/sessions/sacrifice-zones.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: sacrifice-zones
+---

--- a/sessions/saving-the-nhs.ics
+++ b/sessions/saving-the-nhs.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: saving-the-nhs
+---

--- a/sessions/screenprinting.ics
+++ b/sessions/screenprinting.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: screenprinting
+---

--- a/sessions/skills-10.ics
+++ b/sessions/skills-10.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: skills-10
+---

--- a/sessions/skills-2.ics
+++ b/sessions/skills-2.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: skills-2
+---

--- a/sessions/skills-3.ics
+++ b/sessions/skills-3.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: skills-3
+---

--- a/sessions/skills-4.ics
+++ b/sessions/skills-4.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: skills-4
+---

--- a/sessions/skills-5.ics
+++ b/sessions/skills-5.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: skills-5
+---

--- a/sessions/skills-6.ics
+++ b/sessions/skills-6.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: skills-6
+---

--- a/sessions/skills-7.ics
+++ b/sessions/skills-7.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: skills-7
+---

--- a/sessions/skills-8.ics
+++ b/sessions/skills-8.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: skills-8
+---

--- a/sessions/skills-9.ics
+++ b/sessions/skills-9.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: skills-9
+---

--- a/sessions/social-media-analytics-workshop.ics
+++ b/sessions/social-media-analytics-workshop.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: social-media-analytics-workshop
+---

--- a/sessions/social-strike-game.ics
+++ b/sessions/social-strike-game.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: social-strike-game
+---

--- a/sessions/socialist-women-in-labour.ics
+++ b/sessions/socialist-women-in-labour.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: socialist-women-in-labour
+---

--- a/sessions/solidarity-with-palestinians.ics
+++ b/sessions/solidarity-with-palestinians.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: solidarity-with-palestinians
+---

--- a/sessions/sustainability-economics.ics
+++ b/sessions/sustainability-economics.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: sustainability-economics
+---

--- a/sessions/tackling-the-tech-giants.ics
+++ b/sessions/tackling-the-tech-giants.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: tackling-the-tech-giants
+---

--- a/sessions/taking-whats-ours.ics
+++ b/sessions/taking-whats-ours.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: taking-whats-ours
+---

--- a/sessions/tech-workers-inquiry.ics
+++ b/sessions/tech-workers-inquiry.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: tech-workers-inquiry
+---

--- a/sessions/telling-stories-that-build-power.ics
+++ b/sessions/telling-stories-that-build-power.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: telling-stories-that-build-power
+---

--- a/sessions/the-brexit-bind.ics
+++ b/sessions/the-brexit-bind.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: the-brexit-bind
+---

--- a/sessions/the-british-ruling-class.ics
+++ b/sessions/the-british-ruling-class.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: the-british-ruling-class
+---

--- a/sessions/the-european-left.ics
+++ b/sessions/the-european-left.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: the-european-left
+---

--- a/sessions/the-gig-economy.ics
+++ b/sessions/the-gig-economy.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: the-gig-economy
+---

--- a/sessions/things-change.ics
+++ b/sessions/things-change.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: things-change
+---

--- a/sessions/this-is-bate-bola.ics
+++ b/sessions/this-is-bate-bola.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: this-is-bate-bola
+---

--- a/sessions/time-for-10.ics
+++ b/sessions/time-for-10.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: time-for-10
+---

--- a/sessions/towards-a-socialist-government.ics
+++ b/sessions/towards-a-socialist-government.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: towards-a-socialist-government
+---

--- a/sessions/trading-with-trump.ics
+++ b/sessions/trading-with-trump.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: trading-with-trump
+---

--- a/sessions/transform-the-world-14-plus.ics
+++ b/sessions/transform-the-world-14-plus.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: transform-the-world-14-plus
+---

--- a/sessions/transform-the-world-8-to-13.ics
+++ b/sessions/transform-the-world-8-to-13.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: transform-the-world-8-to-13
+---

--- a/sessions/transforming-the-global-economy.ics
+++ b/sessions/transforming-the-global-economy.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: transforming-the-global-economy
+---

--- a/sessions/tribune-relaunch.ics
+++ b/sessions/tribune-relaunch.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: tribune-relaunch
+---

--- a/sessions/twt-football-final.ics
+++ b/sessions/twt-football-final.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: twt-football-final
+---

--- a/sessions/update-the-welfare-state.ics
+++ b/sessions/update-the-welfare-state.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: update-the-welfare-state
+---

--- a/sessions/violence.ics
+++ b/sessions/violence.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: violence
+---

--- a/sessions/wargaming-a-radical-government.ics
+++ b/sessions/wargaming-a-radical-government.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: wargaming-a-radical-government
+---

--- a/sessions/we-are-many.ics
+++ b/sessions/we-are-many.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: we-are-many
+---

--- a/sessions/why-political-education.ics
+++ b/sessions/why-political-education.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: why-political-education
+---

--- a/sessions/workers-control-in-economic-planning.ics
+++ b/sessions/workers-control-in-economic-planning.ics
@@ -1,0 +1,4 @@
+---
+layout: icalendar
+slug: workers-control-in-economic-planning
+---


### PR DESCRIPTION
This PR adds support for exporting each session to an `.ics` file, alongside the existing Google Calendar option.

For every `sessions/{slug}.html` file, we now also generate a corresponding `sessions/{slug}.ics` file. A new `icalendar.ics` layout is used to generate an iCalendar file for every session, and we link straight to it from the HTML version.

It seems that Jekyll (and hopefully GitHub Pages) will automatically detect the MIME type and send back a `text/calendar` Content-Type header.

The real struggle is how to display this in the UI. For now, I've gone with the super simple approach (inspired by Eventbrite's UI) of opening a Semantic UI modal when the user clicks on the "Add to calendar button". In the modal, they get the option of a Google Calendar or an "Apple" export. I am definitely open to suggestions because there are clearly better ways that we could do this.

![screen shot 2018-09-16 at 15 06 28](https://user-images.githubusercontent.com/362164/45597310-1f04c380-b9c2-11e8-95d7-db91fde46d70.png)

![screen shot 2018-09-16 at 15 04 28](https://user-images.githubusercontent.com/362164/45597298-f41a6f80-b9c1-11e8-9ba8-ad178c138e82.png)

On a happier note, the "Add to calendar" button will degrade gracefully as the modal only kicks in if JavaScript is enabled – otherwise, we go ahead with the Google Calendar export as before.

Let me know what you think; happy to make any changes as needed.